### PR TITLE
Allow it to install on PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "code-sniffer-fix": "./vendor/bin/phpcbf --standard=PSR2 src"
   },
   "require": {
-    "php": "~7.1",
+    "php": ">=7.1",
     "league/commonmark": "^0.17"
   },
   "require-dev": {


### PR DESCRIPTION
While we wait for this to be merged in, modify your `composer.json`:

```json
{
  "repositories": [
    {
      "url": "https://github.com/live627/changelog-parser.git",
      "type": "vcs"
    }
  ],
  "minimum-stability": "dev",
  "require-dev": {
    "tfarla/changelog-parser": "dev-master"
  }
}
```

Now you can run

```bash
composer install
 ```